### PR TITLE
feat: automate Artifact Registry maintenance notifications

### DIFF
--- a/infrastructure/gcp/artifact-maintenance-notify.workflow.yaml
+++ b/infrastructure/gcp/artifact-maintenance-notify.workflow.yaml
@@ -1,0 +1,20 @@
+# Eventarc passes a matching Cloud Audit Logs event as `event`.
+# The workflow reads the Slack webhook only at execution time; it never logs it.
+main:
+  params: [event]
+  steps:
+    - get_webhook:
+        call: googleapis.secretmanager.v1.projects.secrets.versions.accessString
+        args:
+          project_id: simple-alert-line-bot
+          secret_id: simple-alert-maintenance-slack-webhook
+          version: latest
+        result: webhook_url
+    - notify_slack:
+        call: http.post
+        args:
+          url: ${webhook_url}
+          headers:
+            Content-Type: application/json
+          body:
+            text: '${"Artifact Registry maintenance executed | Repository: simple-alert-line-bot (asia-northeast1) | Operation: " + event.data.protoPayload.methodName + " | Resource: " + event.data.protoPayload.resourceName}'

--- a/infrastructure/gcp/artifact-registry-cleanup-policy.json
+++ b/infrastructure/gcp/artifact-registry-cleanup-policy.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "keep-latest-10",
+    "action": {"type": "Keep"},
+    "mostRecentVersions": {
+      "packageNamePrefixes": ["app"],
+      "keepCount": 10
+    }
+  },
+  {
+    "name": "delete-old-versions",
+    "action": {"type": "Delete"},
+    "condition": {
+      "packageNamePrefixes": ["app"],
+      "tagState": "ANY",
+      "olderThan": "1209600s"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- keep the latest 10 `app` image versions and delete versions older than 14 days
- notify Slack through Eventarc and Workflows whenever an Artifact Registry tag deletion is audited
- retrieve the Slack webhook at execution time from Secret Manager only

## GCP resources configured

- Artifact Registry cleanup policies on `simple-alert-line-bot` (active, not dry-run)
- Workflow `simple-alert-artifact-maintenance-notify`
- Eventarc trigger `simple-alert-artifact-maintenance-notify`
- least-privilege service account `sa-maintenance-notifier`

## Validation

- cleanup policy dry-run verified before activation; no current deletion candidates (9 versions)
- Workflow test notification succeeded
- end-to-end temporary-tag removal triggered Eventarc execution `a2f89938-f69d-494a-9265-494c87f80135` successfully
- `jq empty infrastructure/gcp/artifact-registry-cleanup-policy.json`
- `git diff --check`

## Cost

Expected ¥0 under current free tiers. No Cloud Build or new container image is used. Workflows, Eventarc, Pub/Sub transfer, and Secret Manager access remain within the documented free usage at this expected volume.