### PR TITLE
fix: make Firestore tests explicit and gate deploys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,11 @@ jobs:
           mongodb-port: 27017
       - name: Test with pytest
         env:
+          # テスト環境は development 扱いにし、本番用 FLASK_SECRET_KEY ガードを回避する
+          FLASK_ENV: development
+          # 既定では Firestore 結合テストを実行しない（decision: firestore-test-strategy）
+          RUN_FIRESTORE_INTEGRATION_TESTS: "0"
+          FIRESTORE_EMULATOR_HOST: ""
           OPEN_WEATHER_MAP_API_KEY: ${{ secrets.OPEN_WEATHER_MAP_API_KEY }}
           LINEBOT_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINEBOT_CHANNEL_ACCESS_TOKEN }}
           LINEBOT_CHANNEL_SECRET: ${{ secrets.LINEBOT_CHANNEL_SECRET }}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
       - "-c"
       - |
         pip install --quiet ruff
-        ruff check . --config ruff.toml || echo "⚠ lint warnings found（非ブロッキング）"
+        ruff check . --config ruff.toml --select E9,F63,F7,F82
     waitFor: ["-"]
 
   # ─── Step 2: Test + Coverage ───
@@ -23,6 +23,7 @@ steps:
     env:
       - "FLASK_ENV=development"
       - "FIRESTORE_EMULATOR_HOST="
+      - "RUN_FIRESTORE_INTEGRATION_TESTS=0"
     args:
       - "-c"
       - |
@@ -32,9 +33,8 @@ steps:
           --ignore=src/conftest.py \
           --cov=src \
           --cov-fail-under=${_MIN_COVERAGE} \
-          --tb=short -q \
-          || echo "⚠ テスト未通過（非ブロッキング）"
-    waitFor: ["-"]
+          --tb=short -q
+    waitFor: ["lint", "test", "security-scan"]
 
   # ─── Step 3: Security scan ───
   - id: "security-scan"
@@ -45,7 +45,7 @@ steps:
       - |
         pip install --quiet pip-audit
         pip install --quiet -r requirements.txt
-        pip-audit --strict --desc || echo "⚠ pip-audit found issues（非ブロッキング）"
+        pip-audit --strict --desc -r requirements.txt
     waitFor: ["-"]
 
   # ─── Step 4: Docker build ───

--- a/conftest.py
+++ b/conftest.py
@@ -3,16 +3,34 @@ import urllib.error
 import urllib.request
 
 import pytest
-import google.auth
-from google.auth.exceptions import DefaultCredentialsError
 
 
-def _has_adc() -> bool:
-    try:
-        google.auth.default()
-        return True
-    except DefaultCredentialsError:
-        return False
+def _integration_tests_enabled() -> bool:
+    return os.getenv("RUN_FIRESTORE_INTEGRATION_TESTS") == "1"
+
+
+def _configure_firestore_test_project() -> None:
+    if not _integration_tests_enabled():
+        return
+
+    test_project_id = (os.getenv("FIRESTORE_TEST_PROJECT_ID") or "").strip()
+    production_project_id = (
+        os.getenv("FIRESTORE_PRODUCTION_PROJECT_ID") or "simple-alert-line-bot"
+    ).strip()
+    if not test_project_id:
+        raise pytest.UsageError(
+            "FIRESTORE_TEST_PROJECT_ID is required when "
+            "RUN_FIRESTORE_INTEGRATION_TESTS=1."
+        )
+    if test_project_id == production_project_id:
+        raise pytest.UsageError(
+            "Firestore integration tests must not use the production project."
+        )
+
+    os.environ["FIRESTORE_PROJECT_ID"] = test_project_id
+
+
+_configure_firestore_test_project()
 
 
 def _emulator_host() -> str:
@@ -48,11 +66,15 @@ def _clear_firestore_emulator_between_tests():
 
 
 def pytest_collection_modifyitems(config, items):
-    if _has_emulator() or _has_adc():
+    if _integration_tests_enabled():
         return
 
     skip = pytest.mark.skip(
-        reason="Skipping Firestore integration tests: Application Default Credentials not configured."
+        reason=(
+            "Skipping Firestore integration tests: set "
+            "RUN_FIRESTORE_INTEGRATION_TESTS=1 and FIRESTORE_TEST_PROJECT_ID "
+            "to run against a dedicated non-production project."
+        )
     )
     for item in items:
         path = str(item.fspath)

--- a/docs/decisions/2026-07-19-firestore-test-strategy.md
+++ b/docs/decisions/2026-07-19-firestore-test-strategy.md
@@ -1,0 +1,25 @@
+# Firestore test strategy
+
+- Date: 2026-07-19
+- Status: Accepted
+
+## Decision
+
+- The default local and CI test suites do not start Firestore Emulator.
+- Firestore integration tests are opt-in with `RUN_FIRESTORE_INTEGRATION_TESTS=1`.
+- Opt-in runs require `FIRESTORE_TEST_PROJECT_ID` and reject the production project ID.
+- Unit tests use dummy or fake repositories and must not depend on Application Default Credentials.
+- The deployment pipeline must stop when lint, unit tests, or dependency auditing fails.
+
+## Context
+
+Firestore Emulator had already been evaluated and was not selected as the default CI path. The repository later retained emulator scripts, which made it easy to mistake them for the intended architecture. Inferring whether integration tests should run from the presence of Application Default Credentials was also unsafe because Cloud Build has credentials and could access a real Firestore project.
+
+## Change-safety rule
+
+Before replacing test infrastructure or CI architecture, inspect the relevant Git history and existing decision records. Do not infer architectural intent from the presence of scripts alone.
+
+## Future work
+
+- Increase coverage through in-memory fake repositories.
+- If real Firestore compatibility tests are needed, run them separately against a dedicated disposable test project with an explicit cost and cleanup policy.

--- a/src/UseCases/Line/tests/test_handle_intent_operation_use_case.py
+++ b/src/UseCases/Line/tests/test_handle_intent_operation_use_case.py
@@ -104,7 +104,7 @@ class DummyIntentParserService:
         # メッセージ部分文字列 → 返却値 のマッピング（テスト用）
         self.extra_responses = extra_responses or {}
 
-    def parse(self, message: str, existing_items=None):
+    def parse(self, message: str, existing_items=None, openai_api_key=None):
         for substring, response in self.extra_responses.items():
             if substring in message:
                 return response

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,13 +1,15 @@
 # flake8: noqa
 import os
 import sys
+from pathlib import Path
+
 import pytest
 from dotenv import load_dotenv
 from src.firestore_client import firestore_client
 from src import app
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
-load_dotenv()
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / '.env')
 
 
 @pytest.fixture()


### PR DESCRIPTION
## What changed

- make Firestore integration tests explicit opt-in
- require a dedicated non-production Firestore project for integration tests
- reject the production project ID before test collection
- make Cloud Build lint, unit tests, and dependency auditing block the Docker build
- fix dotenv loading so tests work from any clone path
- update the intent parser test dummy for per-user OpenAI API keys
- record the Firestore testing decision in the repository

## Why

The previous test selection inferred intent from Application Default Credentials. Cloud Build and developer machines can have ADC, which could make tests contact a real Firestore project. Firestore Emulator scripts also remained in the repository even though the intended default strategy was moving toward isolated unit tests.

## Impact

Normal CI no longer contacts Firestore. Integration tests require explicit opt-in and a dedicated non-production project. Deployments stop when critical lint, unit tests, or dependency auditing fails.

## Validation

- 93 unit tests passed
- 92 Firestore-dependent tests skipped by default
- coverage: 58.50% (threshold: 30%)
- critical Ruff checks passed
- production Firestore project guard rejected test startup as expected
- dependency audit correctly blocks deployment: 25 known vulnerabilities across 7 packages remain and are tracked in Linear FEZ-15