### PR TITLE
fix: LINEトークン未設定でも import 時に落ちないようにする (FEZ-15)

### DIFF
--- a/src/line_bot_api.py
+++ b/src/line_bot_api.py
@@ -2,5 +2,8 @@ from src import config
 from linebot import (LineBotApi, WebhookHandler)
 
 # setup for line-bot-sdk
-line_bot_api = LineBotApi(config.LINEBOT_CHANNEL_ACCESS_TOKEN)
-handler = WebhookHandler(config.LINEBOT_CHANNEL_SECRET)
+# トークン未設定（CI・テスト・.env 無しのローカル等）でも import 時に
+# linebot SDK が None を連結して落ちないよう、ダミー値でフォールバックする。
+# 本番では Secret 経由で実値が注入されるためフォールバックは使われない。
+line_bot_api = LineBotApi(config.LINEBOT_CHANNEL_ACCESS_TOKEN or "dummy")
+handler = WebhookHandler(config.LINEBOT_CHANNEL_SECRET or "dummy")


### PR DESCRIPTION
## 概要
FEZ-15 マージ後の Cloud Build が `test` ステップで失敗していた問題を修正。

## 原因
`src/line_bot_api.py` が import 時に `LineBotApi(config.LINEBOT_CHANNEL_ACCESS_TOKEN)` を生成する。Cloud Build の test ステップは LINE トークンを渡していないため None となり、linebot SDK 内で `can only concatenate str (not "NoneType")` が発生。conftest import 失敗で test ステップが落ち、ゲートによりデプロイも停止していた（GitHub Actions は secrets 経由でトークンを渡すため通過していた）。

## 変更
- トークン未設定時はダミー値でフォールバックして import 安全にする（本番は Secret 経由で実値注入のため影響なし）。

## 検証（ローカル・Python 3.11・.env 退避・LINEトークン無し = CI相当）
- 96 passed / 92 skipped、カバレッジ 58.91%（`--cov-fail-under=30` 通過）